### PR TITLE
Add Terraform and Ansible CI/CD reference implementation

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -11,6 +11,7 @@ on:
       - 'ansible/**'
       - 'scripts/**'
       - '.github/workflows/app.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -18,6 +19,7 @@ permissions:
 
 jobs:
   ansible:
+    if: ${{ vars.ENABLE_ANSIBLE_CICD == 'true' }}
     runs-on: ubuntu-latest
     env:
       AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -1,0 +1,83 @@
+name: ansible-ci-cd
+
+on:
+  push:
+    paths:
+      - 'ansible/**'
+      - 'scripts/**'
+      - '.github/workflows/app.yml'
+  pull_request:
+    paths:
+      - 'ansible/**'
+      - 'scripts/**'
+      - '.github/workflows/app.yml'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  ansible:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      ANSIBLE_CONFIG: ansible/ansible.cfg
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible==8.5.0 ansible-lint boto3 botocore
+          ansible-galaxy collection install -r ansible/collections/requirements.yml
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Ansible lint
+        run: ansible-lint ansible
+
+      - name: Unit tests
+        run: ansible-playbook ansible/tests/unit.yml --check -i localhost,
+
+      - name: Deploy to green
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          ansible-playbook ansible/playbooks/deploy.yml \
+            -i ansible/inventories/dynamic_aws_ec2.yml \
+            --limit tag_Deployment_green \
+            -e target_color=green
+
+      - name: Smoke tests
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: ./scripts/smoke-test.sh "${{ secrets.ALB_URL }}"
+
+      - name: Switch traffic to green
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        env:
+          TARGET_COLOR: green
+          ALB_LISTENER_ARN: ${{ secrets.ALB_LISTENER_ARN }}
+          BLUE_TARGET_GROUP_ARN: ${{ secrets.BLUE_TARGET_GROUP_ARN }}
+          GREEN_TARGET_GROUP_ARN: ${{ secrets.GREEN_TARGET_GROUP_ARN }}
+        run: ./scripts/switch-target-group.sh "$TARGET_COLOR"
+
+      - name: Scale down blue ASG
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        env:
+          BLUE_ASG_NAME: ${{ secrets.BLUE_ASG_NAME }}
+        run: |
+          ansible-playbook ansible/playbooks/decommission.yml \
+            -i localhost, \
+            --limit localhost \
+            -e target_color=blue \
+            -e asg_name=$BLUE_ASG_NAME

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - 'infrastructure/**'
       - '.github/workflows/infra.yml'
+  workflow_dispatch:
+
 
 permissions:
   contents: read
@@ -16,6 +18,7 @@ permissions:
 
 jobs:
   terraform:
+    if: ${{ vars.ENABLE_TERRAFORM_CICD == 'true' }}
     name: Terraform plan & apply
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,72 @@
+name: terraform-ci-cd
+
+on:
+  push:
+    paths:
+      - 'infrastructure/**'
+      - '.github/workflows/infra.yml'
+  pull_request:
+    paths:
+      - 'infrastructure/**'
+      - '.github/workflows/infra.yml'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  terraform:
+    name: Terraform plan & apply
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infrastructure
+    env:
+      TF_IN_AUTOMATION: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init
+        if: ${{ vars.TERRAFORM_BACKEND_CONFIG == '' }}
+        run: terraform init -input=false
+
+      - name: Terraform init with backend config
+        if: ${{ vars.TERRAFORM_BACKEND_CONFIG != '' }}
+        run: terraform init -input=false -backend-config="${{ vars.TERRAFORM_BACKEND_CONFIG }}"
+
+      - name: Terraform validate
+        run: terraform validate
+
+      - name: Terraform plan
+        id: plan
+        run: terraform plan -input=false -var-file="env/${{ vars.TERRAFORM_ENVIRONMENT }}.tfvars" -out=tfplan
+
+      - name: Export plan for PR comment
+        if: github.event_name == 'pull_request'
+        run: terraform show -no-color tfplan > plan.out
+
+      - name: Terraform plan (PR comment)
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: infrastructure/plan.out
+
+      - name: Terraform apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -input=false tfplan

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+infrastructure/.terraform/
+infrastructure/.terraform.lock.hcl
+infrastructure/backend.hcl
+*.tfstate
+*.tfstate.*

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Actions → New repository secret):
 | `BLUE_TARGET_GROUP_ARN`    | ARN for the blue target group |
 | `GREEN_TARGET_GROUP_ARN`   | ARN for the green target group |
 | `BLUE_ASG_NAME`            | Blue Auto Scaling group name (for scale-down) |
+| `GREEN_ASG_NAME`           | Green Auto Scaling group name (for manual rollbacks) |
 
 Define the following **repository variables** to avoid hard-coded values in the
 workflow files and to control when automation is allowed to run:

--- a/README.md
+++ b/README.md
@@ -109,15 +109,22 @@ Actions → New repository secret):
 | `BLUE_ASG_NAME`            | Blue Auto Scaling group name (for scale-down) |
 
 Define the following **repository variables** to avoid hard-coded values in the
-workflow files:
+workflow files and to control when automation is allowed to run:
 
 | Variable name               | Suggested value |
 |-----------------------------|-----------------|
+| `ENABLE_TERRAFORM_CICD`     | `false` (set to `true` once secrets/backends are ready) |
+| `ENABLE_ANSIBLE_CICD`       | `false` (set to `true` once secrets/targets are ready) |
 | `TERRAFORM_ENVIRONMENT`     | `prod` (matches `env/prod.tfvars`) |
 | `TERRAFORM_BACKEND_CONFIG`  | `backend.hcl` (if using remote state file) |
 
-> ℹ️  `TERRAFORM_BACKEND_CONFIG` is optional. When omitted, Terraform will use
-> the local backend. When provided, a file with that name must exist in the
+> ℹ️  Leave `ENABLE_TERRAFORM_CICD` and `ENABLE_ANSIBLE_CICD` at their default
+> `false` until the corresponding secrets, backend files, and target resources
+> exist; the workflows will be skipped instead of failing. Set them to `true`
+> when you are ready for automation to execute.
+>
+> `TERRAFORM_BACKEND_CONFIG` is optional. When omitted, Terraform will use the
+> local backend. When provided, a file with that name must exist in the
 > `infrastructure/` directory (see bootstrapping section above).
 
 If you plan to run the Ansible workflow against a different AWS region or
@@ -161,8 +168,9 @@ use Terraform outputs stored as GitHub secrets to manipulate the load balancer.
 * **Smoke tests** can be extended by editing `scripts/smoke-test.sh` or replacing
   it with a more comprehensive suite (e.g., pytest hitting the ALB URL).
 
-Submit a pull request; GitHub Actions will run the relevant pipeline(s).
-Merging to `main` triggers the automated apply/deploy stages.
+Submit a pull request; once the enablement variables are set to `true`, GitHub
+Actions will run the relevant pipeline(s). Merging to `main` triggers the
+automated apply/deploy stages.
 
 ## Local testing
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,227 @@
-# ipgdemo
+# ipgdemo – Terraform + Ansible Blue/Green CI/CD
+
+This repository implements a reference CI/CD workflow that provisions AWS
+infrastructure with Terraform and deploys an NGINX-based sample application with
+Ansible. GitHub Actions orchestrates both infrastructure and application
+pipelines and performs a simple blue/green cutover after smoke tests succeed.
+
+The design is intentionally modular so that instance sizing, launch templates,
+or application configuration changes can be made with pull requests while
+keeping infrastructure and configuration-as-code in a single repository.
+
+## Repository layout
+
+```
+.
+├── .github/workflows/       # GitHub Actions pipelines
+│   ├── infra.yml            # Terraform plan/apply workflow
+│   └── app.yml              # Ansible deploy + blue/green workflow
+├── ansible/                 # Application configuration
+│   ├── ansible.cfg
+│   ├── collections/
+│   │   └── requirements.yml
+│   ├── inventories/
+│   │   └── dynamic_aws_ec2.yml
+│   ├── playbooks/
+│   │   ├── deploy.yml
+│   │   └── decommission.yml
+│   ├── roles/
+│   │   └── hello_app/
+│   │       ├── tasks/main.yml
+│   │       └── templates/
+│   └── tests/unit.yml
+├── infrastructure/          # Terraform root module and environment vars
+│   ├── main.tf
+│   ├── variables.tf
+│   ├── outputs.tf
+│   ├── modules/
+│   │   ├── network/
+│   │   └── compute/
+│   └── env/
+│       ├── prod.tfvars
+│       └── staging.tfvars
+├── scripts/
+│   ├── smoke-test.sh        # Curl-based health check
+│   └── switch-target-group.sh
+└── README.md
+```
+
+## Prerequisites
+
+* AWS account with permissions to manage VPC, EC2, ELB, Auto Scaling, IAM,
+  CloudWatch and DynamoDB.
+* Terraform `>= 1.5.0` and Ansible `>= 8` for local testing.
+* An S3 bucket + DynamoDB table for Terraform remote state/locking.
+* IAM user or role for GitHub Actions with permissions for the above services.
+* AWS CLI configured locally for bootstrapping and troubleshooting.
+* The GitHub repository must have Actions enabled.
+
+## Bootstrapping infrastructure
+
+1. **Prepare remote state (recommended).**
+   ```bash
+   aws s3 mb s3://<your-state-bucket>
+   aws dynamodb create-table \
+     --table-name terraform-locks \
+     --attribute-definitions AttributeName=LockID,AttributeType=S \
+     --key-schema AttributeName=LockID,KeyType=HASH \
+     --billing-mode PAY_PER_REQUEST
+   cp infrastructure/backend.hcl.example infrastructure/backend.hcl
+   # edit backend.hcl with your bucket, key, region, and lock table
+   ```
+2. **Select the environment variables file.** Update
+   `infrastructure/env/prod.tfvars` (or create new files per environment) with
+   CIDR ranges, instance sizes, and SSH access CIDRs that match your standards.
+3. **Provision the stack locally once** to capture initial outputs:
+   ```bash
+   cd infrastructure
+   terraform init -backend-config=backend.hcl
+   terraform workspace new prod    # optional, but recommended
+   terraform plan -var-file=env/prod.tfvars
+   terraform apply -var-file=env/prod.tfvars
+   terraform output
+   ```
+4. **Record the outputs** for use by GitHub Actions:
+   * `alb_dns_name` → prepend `http://` and store as `ALB_URL`
+   * `alb_listener_arn` → `ALB_LISTENER_ARN`
+   * `blue_target_group_arn` → `BLUE_TARGET_GROUP_ARN`
+   * `green_target_group_arn` → `GREEN_TARGET_GROUP_ARN`
+   * `blue_asg_name` → `BLUE_ASG_NAME`
+   * `green_asg_name` → `GREEN_ASG_NAME` (used for rollbacks/manual ops)
+
+The Terraform module creates an internet-facing Application Load Balancer with
+blue and green Auto Scaling groups, tagged so Ansible can target them.
+
+## GitHub Actions configuration
+
+Add the following **repository secrets** (Settings → Secrets and variables →
+Actions → New repository secret):
+
+| Secret name                | Description |
+|----------------------------|-------------|
+| `AWS_ACCESS_KEY_ID`        | Access key for the automation IAM user/role |
+| `AWS_SECRET_ACCESS_KEY`    | Secret key for the automation IAM user/role |
+| `AWS_REGION`               | Region that matches Terraform deployments |
+| `ALB_URL`                  | URL used by smoke tests (e.g. `http://<alb_dns>`) |
+| `ALB_LISTENER_ARN`         | ARN for the ALB HTTP listener |
+| `BLUE_TARGET_GROUP_ARN`    | ARN for the blue target group |
+| `GREEN_TARGET_GROUP_ARN`   | ARN for the green target group |
+| `BLUE_ASG_NAME`            | Blue Auto Scaling group name (for scale-down) |
+
+Define the following **repository variables** to avoid hard-coded values in the
+workflow files:
+
+| Variable name               | Suggested value |
+|-----------------------------|-----------------|
+| `TERRAFORM_ENVIRONMENT`     | `prod` (matches `env/prod.tfvars`) |
+| `TERRAFORM_BACKEND_CONFIG`  | `backend.hcl` (if using remote state file) |
+
+> ℹ️  `TERRAFORM_BACKEND_CONFIG` is optional. When omitted, Terraform will use
+> the local backend. When provided, a file with that name must exist in the
+> `infrastructure/` directory (see bootstrapping section above).
+
+If you plan to run the Ansible workflow against a different AWS region or
+environment, adjust `ansible/inventories/dynamic_aws_ec2.yml` accordingly
+(change the `regions` list or add additional filters).
+
+## How the pipelines work
+
+### Infrastructure (`.github/workflows/infra.yml`)
+
+* Runs on pull requests and pushes touching `infrastructure/`.
+* Executes `terraform fmt`, `terraform init`, `terraform validate`, and
+  `terraform plan` with the environment-specific `.tfvars` file.
+* On pull requests, uploads the plan as a sticky PR comment.
+* On merge to `main`, automatically runs `terraform apply` using the saved plan
+  output.
+
+### Application (`.github/workflows/app.yml`)
+
+* Runs linting (`ansible-lint`) and a dry-run unit playbook on all pushes/PRs.
+* On merge to `main`:
+  1. Deploys the role to the **green** Auto Scaling group only.
+  2. Executes `scripts/smoke-test.sh` against the ALB URL.
+  3. Calls `scripts/switch-target-group.sh` to update the listener to forward
+     traffic to the green target group.
+  4. Scales the blue Auto Scaling group to zero capacity via
+     `playbooks/decommission.yml`.
+* To roll back, re-run the workflow with `TARGET_COLOR=blue` (manually) or run
+  `scripts/switch-target-group.sh blue` followed by a deployment to blue.
+
+The scripts expect AWS CLI credentials (provided via the configured secrets) and
+use Terraform outputs stored as GitHub secrets to manipulate the load balancer.
+
+## Making changes
+
+* **Infrastructure tweaks** (e.g., instance size changes) happen under
+  `infrastructure/`. Update `env/*.tfvars` for per-environment overrides.
+* **Application updates** (HTML template, banner text, packages) live under
+  `ansible/roles/hello_app/`. The dynamic inventory groups hosts based on the
+  `Deployment` tag, so the workflow can deploy only to the target color.
+* **Smoke tests** can be extended by editing `scripts/smoke-test.sh` or replacing
+  it with a more comprehensive suite (e.g., pytest hitting the ALB URL).
+
+Submit a pull request; GitHub Actions will run the relevant pipeline(s).
+Merging to `main` triggers the automated apply/deploy stages.
+
+## Local testing
+
+Before opening a PR you can run the same checks locally:
+
+```bash
+# Terraform
+cd infrastructure
+terraform fmt -recursive
+terraform validate
+terraform plan -var-file=env/staging.tfvars
+
+# Ansible
+cd ../ansible
+ansible-galaxy collection install -r collections/requirements.yml
+ansible-lint
+ansible-playbook tests/unit.yml --check -i localhost,
+```
+
+To deploy manually to a specific color from your workstation:
+
+```bash
+ansible-playbook playbooks/deploy.yml \
+  -i inventories/dynamic_aws_ec2.yml \
+  --limit tag_Deployment_green \
+  -e target_color=green
+```
+
+After validating, switch traffic:
+
+```bash
+export ALB_LISTENER_ARN=... BLUE_TARGET_GROUP_ARN=... GREEN_TARGET_GROUP_ARN=...
+scripts/switch-target-group.sh green
+```
+
+## Operational tips & extensions
+
+* Protect the `main` branch and require PR approval before Terraform applies or
+  blue/green cutovers.
+* Add additional Terraform validations (`tflint`, `terraform validate
+  -json`) or security scanners as needed.
+* Integrate Molecule tests for the Ansible role or Terratest for infrastructure
+  regression coverage.
+* Consider adding manual approval steps (GitHub environments) before
+  `terraform apply` or traffic switching for production environments.
+* Store secrets such as database credentials in AWS Systems Manager Parameter
+  Store or Secrets Manager; reference them from Ansible roles via the
+  `aws_ssm` lookup.
+* For immutable deployments, replace Ansible with Packer-built AMIs or
+  container images – the blue/green infrastructure pattern remains useful.
+
+## Cleanup
+
+To remove the demo stack:
+
+```bash
+cd infrastructure
+terraform destroy -var-file=env/prod.tfvars
+```
+
+Ensure no additional resources (e.g., DNS records) depend on the load balancer
+before destroying the environment.

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,10 @@
+[defaults]
+inventory = inventories/dynamic_aws_ec2.yml
+host_key_checking = False
+retry_files_enabled = False
+stdout_callback = yaml
+interpreter_python = auto
+collections_paths = ~/.ansible/collections:./collections
+
+[inventory]
+enable_plugins = aws_ec2, yaml, ini, host_list

--- a/ansible/collections/requirements.yml
+++ b/ansible/collections/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: community.aws
+  - name: amazon.aws

--- a/ansible/inventories/dynamic_aws_ec2.yml
+++ b/ansible/inventories/dynamic_aws_ec2.yml
@@ -1,0 +1,15 @@
+plugin: aws_ec2
+regions:
+  - us-east-1
+hostnames:
+  - tag:Name
+  - private-ip-address
+compose:
+  ansible_host: public_ip_address
+filters:
+  tag:Environment: production
+keyed_groups:
+  - key: tags.Deployment
+    prefix: tag_Deployment_
+  - key: tags.Role
+    prefix: tag_Role_

--- a/ansible/playbooks/decommission.yml
+++ b/ansible/playbooks/decommission.yml
@@ -1,0 +1,23 @@
+---
+- name: Scale down inactive Auto Scaling group
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    target_color: "{{ target_color | default('blue') }}"
+  pre_tasks:
+    - name: Validate input variables
+      ansible.builtin.assert:
+        that:
+          - target_color in ['blue', 'green']
+          - asg_name is defined
+        fail_msg: "Provide target_color (blue|green) and asg_name variables."
+  tasks:
+    - name: Scale down Auto Scaling group
+      community.aws.autoscaling_group:
+        name: "{{ asg_name }}"
+        desired_capacity: 0
+        min_size: 0
+        max_size: 0
+        wait_for_instances: true
+        state: present

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -1,0 +1,20 @@
+---
+- name: Deploy hello app to target color
+  hosts: tag_Role_web
+  gather_facts: true
+  become: true
+  vars:
+    environment: production
+    ansible_user: ec2-user
+  pre_tasks:
+    - name: Assert target color provided
+      ansible.builtin.assert:
+        that:
+          - target_color is defined
+          - target_color in ['blue', 'green']
+        fail_msg: "target_color must be provided as 'blue' or 'green'"
+  roles:
+    - role: hello_app
+      vars:
+        target_color: "{{ target_color }}"
+        environment: "{{ environment }}"

--- a/ansible/roles/hello_app/tasks/main.yml
+++ b/ansible/roles/hello_app/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Ensure base packages present
+  ansible.builtin.yum:
+    name:
+      - nginx
+    state: present
+
+- name: Deploy index.html
+  ansible.builtin.template:
+    src: index.html.j2
+    dest: /usr/share/nginx/html/index.html
+    mode: '0644'
+
+- name: Configure login banner
+  ansible.builtin.template:
+    src: motd.j2
+    dest: /etc/motd
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Enable and start nginx
+  ansible.builtin.service:
+    name: nginx
+    state: started
+    enabled: true

--- a/ansible/roles/hello_app/templates/index.html.j2
+++ b/ansible/roles/hello_app/templates/index.html.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ app_title | default('Hello from Blue/Green!') }}</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 4rem; text-align: center; }
+    h1 { color: #0b5fff; }
+    p { color: #555; }
+  </style>
+</head>
+<body>
+  <h1>{{ app_heading | default('Hello from the ' ~ (target_color | default('green')) ~ ' stack!') }}</h1>
+  <p>{{ app_message | default('This page is served from an EC2 instance configured by Ansible.') }}</p>
+  <footer>
+    <p>Deployed at {{ ansible_date_time.iso8601 }}</p>
+  </footer>
+</body>
+</html>

--- a/ansible/roles/hello_app/templates/motd.j2
+++ b/ansible/roles/hello_app/templates/motd.j2
@@ -1,0 +1,5 @@
+***************************************************
+ Welcome to the {{ environment | default('production') }} environment.
+ Active deployment color: {{ target_color | default('green') | upper }}
+ Managed by Ansible on {{ ansible_date_time.date }} at {{ ansible_date_time.time }}
+***************************************************

--- a/ansible/tests/unit.yml
+++ b/ansible/tests/unit.yml
@@ -1,0 +1,12 @@
+---
+- name: Validate hello_app role
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    target_color: green
+    environment: ci
+  tasks:
+    - name: Include hello_app role
+      ansible.builtin.include_role:
+        name: hello_app

--- a/infrastructure/backend.hcl.example
+++ b/infrastructure/backend.hcl.example
@@ -1,0 +1,5 @@
+bucket         = "your-terraform-state-bucket"
+key            = "ipgdemo/terraform.tfstate"
+region         = "us-east-1"
+dynamodb_table = "terraform-locks"
+encrypt        = true

--- a/infrastructure/env/prod.tfvars
+++ b/infrastructure/env/prod.tfvars
@@ -1,0 +1,12 @@
+environment          = "production"
+region               = "us-east-1"
+name_prefix          = "ipgdemo"
+vpc_cidr             = "10.20.0.0/16"
+instance_type        = "t3.small"
+asg_desired_capacity = 2
+ssh_allowed_cidr     = ["203.0.113.0/24"]
+health_check_path    = "/"
+additional_tags = {
+  Owner       = "platform-team"
+  CostCenter  = "1234"
+}

--- a/infrastructure/env/staging.tfvars
+++ b/infrastructure/env/staging.tfvars
@@ -1,0 +1,12 @@
+environment          = "staging"
+region               = "us-east-1"
+name_prefix          = "ipgdemo-stg"
+vpc_cidr             = "10.30.0.0/16"
+instance_type        = "t3.micro"
+asg_desired_capacity = 1
+ssh_allowed_cidr     = ["0.0.0.0/0"]
+health_check_path    = "/"
+additional_tags = {
+  Owner = "platform-team"
+  Stage = "staging"
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,25 @@
+locals {
+  name_prefix = var.name_prefix
+}
+
+module "network" {
+  source      = "./modules/network"
+  name_prefix = local.name_prefix
+  environment = var.environment
+  vpc_cidr    = var.vpc_cidr
+  az_count    = var.az_count
+}
+
+module "compute" {
+  source              = "./modules/compute"
+  name_prefix         = local.name_prefix
+  environment         = var.environment
+  vpc_id              = module.network.vpc_id
+  subnet_ids          = module.network.public_subnet_ids
+  alb_subnet_ids      = module.network.public_subnet_ids
+  instance_type       = var.instance_type
+  asg_desired_capacity = var.asg_desired_capacity
+  ssh_allowed_cidr    = var.ssh_allowed_cidr
+  health_check_path   = var.health_check_path
+  additional_tags     = var.additional_tags
+}

--- a/infrastructure/modules/compute/main.tf
+++ b/infrastructure/modules/compute/main.tf
@@ -1,0 +1,268 @@
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+locals {
+  ami_id         = var.ami_id != "" ? var.ami_id : data.aws_ami.amazon_linux.id
+  alb_subnet_ids = length(var.alb_subnet_ids) > 0 ? var.alb_subnet_ids : var.subnet_ids
+  common_tags = merge({
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }, var.additional_tags)
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${var.name_prefix}-${var.environment}-alb"
+  description = "Security group for ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Allow HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow all egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-${var.environment}-alb"
+  })
+}
+
+resource "aws_security_group" "instances" {
+  name        = "${var.name_prefix}-${var.environment}-instances"
+  description = "Security group for EC2 instances"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description      = "Allow HTTP from ALB"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    security_groups  = [aws_security_group.alb.id]
+  }
+
+  dynamic "ingress" {
+    for_each = var.ssh_allowed_cidr
+    content {
+      description = "Allow SSH"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  egress {
+    description = "Allow all egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-${var.environment}-instances"
+  })
+}
+
+resource "aws_launch_template" "this" {
+  name_prefix   = "${var.name_prefix}-${var.environment}-lt-"
+  image_id      = local.ami_id
+  instance_type = var.instance_type
+  user_data     = base64encode(templatefile("${path.module}/user_data.sh", {
+    environment = var.environment
+  }))
+
+  vpc_security_group_ids = [aws_security_group.instances.id]
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(local.common_tags, {
+      Name = "${var.name_prefix}-${var.environment}-web"
+      Role = "web"
+    })
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb" "this" {
+  name               = "${var.name_prefix}-${var.environment}-alb"
+  load_balancer_type = "application"
+  internal           = false
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = local.alb_subnet_ids
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-${var.environment}-alb"
+  })
+}
+
+resource "aws_lb_target_group" "blue" {
+  name        = "${var.name_prefix}-${var.environment}-blue"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "instance"
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    path                = var.health_check_path
+    port                = "traffic-port"
+    healthy_threshold   = 3
+    unhealthy_threshold = 5
+    timeout             = 5
+    matcher             = "200"
+  }
+
+  tags = merge(local.common_tags, {
+    Name       = "${var.name_prefix}-${var.environment}-blue"
+    Deployment = "blue"
+  })
+}
+
+resource "aws_lb_target_group" "green" {
+  name        = "${var.name_prefix}-${var.environment}-green"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "instance"
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    path                = var.health_check_path
+    port                = "traffic-port"
+    healthy_threshold   = 3
+    unhealthy_threshold = 5
+    timeout             = 5
+    matcher             = "200"
+  }
+
+  tags = merge(local.common_tags, {
+    Name       = "${var.name_prefix}-${var.environment}-green"
+    Deployment = "green"
+  })
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.blue.arn
+  }
+}
+
+resource "aws_autoscaling_group" "blue" {
+  name                = "${var.name_prefix}-${var.environment}-blue"
+  desired_capacity    = var.asg_desired_capacity
+  max_size            = var.asg_desired_capacity
+  min_size            = var.asg_desired_capacity
+  vpc_zone_identifier = var.subnet_ids
+  health_check_type   = "EC2"
+
+  launch_template {
+    id      = aws_launch_template.this.id
+    version = "$Latest"
+  }
+
+  target_group_arns = [aws_lb_target_group.blue.arn]
+
+  tag {
+    key                 = "Name"
+    value               = "${var.name_prefix}-${var.environment}-blue"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = var.environment
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Deployment"
+    value               = "blue"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Role"
+    value               = "web"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "green" {
+  name                = "${var.name_prefix}-${var.environment}-green"
+  desired_capacity    = var.asg_desired_capacity
+  max_size            = var.asg_desired_capacity
+  min_size            = var.asg_desired_capacity
+  vpc_zone_identifier = var.subnet_ids
+  health_check_type   = "EC2"
+
+  launch_template {
+    id      = aws_launch_template.this.id
+    version = "$Latest"
+  }
+
+  target_group_arns = [aws_lb_target_group.green.arn]
+
+  tag {
+    key                 = "Name"
+    value               = "${var.name_prefix}-${var.environment}-green"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = var.environment
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Deployment"
+    value               = "green"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Role"
+    value               = "web"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/infrastructure/modules/compute/outputs.tf
+++ b/infrastructure/modules/compute/outputs.tf
@@ -1,0 +1,34 @@
+output "alb_dns_name" {
+  description = "DNS name of the ALB"
+  value       = aws_lb.this.dns_name
+}
+
+output "alb_arn" {
+  description = "ARN of the ALB"
+  value       = aws_lb.this.arn
+}
+
+output "alb_listener_arn" {
+  description = "ARN of the HTTP listener"
+  value       = aws_lb_listener.http.arn
+}
+
+output "blue_target_group_arn" {
+  description = "Target group ARN for the blue environment"
+  value       = aws_lb_target_group.blue.arn
+}
+
+output "green_target_group_arn" {
+  description = "Target group ARN for the green environment"
+  value       = aws_lb_target_group.green.arn
+}
+
+output "blue_asg_name" {
+  description = "Name of the blue Auto Scaling group"
+  value       = aws_autoscaling_group.blue.name
+}
+
+output "green_asg_name" {
+  description = "Name of the green Auto Scaling group"
+  value       = aws_autoscaling_group.green.name
+}

--- a/infrastructure/modules/compute/user_data.sh
+++ b/infrastructure/modules/compute/user_data.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euxo pipefail
+
+yum update -y
+amazon-linux-extras enable nginx1
+yum install -y nginx python3 awscli
+systemctl enable nginx
+
+# Allow Ansible to manage without requiring tty
+echo 'Defaults:ec2-user !requiretty' >/etc/sudoers.d/90-ec2-user
+chmod 440 /etc/sudoers.d/90-ec2-user
+
+# Create placeholder index so ALB health checks succeed before Ansible runs
+echo "<html><body><h1>Provisioning {{ environment }} stack</h1></body></html>" >/usr/share/nginx/html/index.html
+systemctl restart nginx

--- a/infrastructure/modules/compute/variables.tf
+++ b/infrastructure/modules/compute/variables.tf
@@ -1,0 +1,61 @@
+variable "name_prefix" {
+  description = "Prefix for compute resources"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment name"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC identifier"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets for Auto Scaling groups"
+  type        = list(string)
+}
+
+variable "alb_subnet_ids" {
+  description = "Subnets where the load balancer will be deployed"
+  type        = list(string)
+  default     = []
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "asg_desired_capacity" {
+  description = "Desired instance count in each Auto Scaling group"
+  type        = number
+  default     = 1
+}
+
+variable "ssh_allowed_cidr" {
+  description = "CIDR blocks allowed to SSH to instances"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "health_check_path" {
+  description = "HTTP health-check path"
+  type        = string
+  default     = "/"
+}
+
+variable "ami_id" {
+  description = "Optional AMI ID to use for the launch template"
+  type        = string
+  default     = ""
+}
+
+variable "additional_tags" {
+  description = "Additional tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/modules/network/main.tf
+++ b/infrastructure/modules/network/main.tf
@@ -1,0 +1,81 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  selected_azs = slice(data.aws_availability_zones.available.names, 0, var.az_count)
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${var.name_prefix}-${var.environment}-vpc"
+    Environment = var.environment
+  }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name        = "${var.name_prefix}-${var.environment}-igw"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name        = "${var.name_prefix}-${var.environment}-public-rt"
+    Environment = var.environment
+  }
+}
+
+resource "aws_subnet" "public" {
+  for_each          = { for index, az in local.selected_azs : az => index }
+  vpc_id            = aws_vpc.this.id
+  availability_zone = each.key
+  cidr_block        = cidrsubnet(var.vpc_cidr, var.public_subnet_cidr_bits, each.value)
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "${var.name_prefix}-${var.environment}-public-${each.value + 1}"
+    Environment = var.environment
+    Tier        = "public"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  for_each       = aws_subnet.public
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = [for subnet in aws_subnet.public : subnet.id]
+}
+
+output "public_subnet_cidrs" {
+  description = "List of public subnet CIDR blocks"
+  value       = [for subnet in aws_subnet.public : subnet.cidr_block]
+}
+
+output "availability_zones" {
+  description = "Availability zones used by the module"
+  value       = local.selected_azs
+}

--- a/infrastructure/modules/network/variables.tf
+++ b/infrastructure/modules/network/variables.tf
@@ -1,0 +1,26 @@
+variable "name_prefix" {
+  description = "Prefix used for naming network resources"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment name"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "az_count" {
+  description = "Number of availability zones to span"
+  type        = number
+  default     = 2
+}
+
+variable "public_subnet_cidr_bits" {
+  description = "Number of additional prefix bits for public subnets"
+  type        = number
+  default     = 8
+}

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -1,0 +1,34 @@
+output "region" {
+  description = "AWS region"
+  value       = var.region
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the application load balancer"
+  value       = module.compute.alb_dns_name
+}
+
+output "alb_listener_arn" {
+  description = "Listener ARN used for traffic switching"
+  value       = module.compute.alb_listener_arn
+}
+
+output "blue_target_group_arn" {
+  description = "Target group ARN for the blue environment"
+  value       = module.compute.blue_target_group_arn
+}
+
+output "green_target_group_arn" {
+  description = "Target group ARN for the green environment"
+  value       = module.compute.green_target_group_arn
+}
+
+output "blue_asg_name" {
+  description = "Auto Scaling group name for the blue environment"
+  value       = module.compute.blue_asg_name
+}
+
+output "green_asg_name" {
+  description = "Auto Scaling group name for the green environment"
+  value       = module.compute.green_asg_name
+}

--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,0 +1,59 @@
+variable "name_prefix" {
+  description = "Prefix added to all resource names"
+  type        = string
+  default     = "ipgdemo"
+}
+
+variable "environment" {
+  description = "Environment identifier (e.g., staging, production)"
+  type        = string
+  default     = "production"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "az_count" {
+  description = "Number of availability zones to use"
+  type        = number
+  default     = 2
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the application"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "asg_desired_capacity" {
+  description = "Number of instances in each Auto Scaling group"
+  type        = number
+  default     = 1
+}
+
+variable "ssh_allowed_cidr" {
+  description = "CIDR blocks allowed SSH access to the instances"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "health_check_path" {
+  description = "HTTP path used by the load balancer health check"
+  type        = string
+  default     = "/"
+}
+
+variable "additional_tags" {
+  description = "Map of additional tags to add to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+  }
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${1:-}"
+
+if [[ -z "$URL" ]]; then
+  echo "Usage: $0 <url>" >&2
+  exit 1
+fi
+
+echo "Running smoke test against $URL"
+response=$(curl -fsS -o /tmp/smoke-body.txt -w "%{http_code}" "$URL")
+
+if [[ "$response" != "200" ]]; then
+  echo "Smoke test failed: expected HTTP 200, got $response" >&2
+  cat /tmp/smoke-body.txt >&2 || true
+  exit 2
+fi
+
+grep -qi "hello" /tmp/smoke-body.txt || {
+  echo "Smoke test failed: response body did not contain expected text" >&2
+  exit 3
+}
+
+echo "Smoke test passed"

--- a/scripts/switch-target-group.sh
+++ b/scripts/switch-target-group.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_COLOR="${1:-}"
+
+if [[ -z "$TARGET_COLOR" ]]; then
+  echo "Usage: $0 <blue|green>" >&2
+  exit 1
+fi
+
+if [[ -z "${ALB_LISTENER_ARN:-}" || -z "${BLUE_TARGET_GROUP_ARN:-}" || -z "${GREEN_TARGET_GROUP_ARN:-}" ]]; then
+  echo "ALB_LISTENER_ARN, BLUE_TARGET_GROUP_ARN and GREEN_TARGET_GROUP_ARN environment variables must be set" >&2
+  exit 2
+fi
+
+case "$TARGET_COLOR" in
+  blue)
+    TARGET_GROUP_ARN="$BLUE_TARGET_GROUP_ARN"
+    ;;
+  green)
+    TARGET_GROUP_ARN="$GREEN_TARGET_GROUP_ARN"
+    ;;
+  *)
+    echo "target color must be 'blue' or 'green'" >&2
+    exit 3
+    ;;
+esac
+
+echo "Switching listener $ALB_LISTENER_ARN to target group $TARGET_GROUP_ARN"
+aws elbv2 modify-listener \
+  --listener-arn "$ALB_LISTENER_ARN" \
+  --default-actions "Type=forward,TargetGroupArn=$TARGET_GROUP_ARN"
+
+echo "Listener updated to $TARGET_COLOR"


### PR DESCRIPTION
## Summary
- add Terraform modules for networking, blue/green compute stacks, and helpful environment tfvars
- implement GitHub Actions pipelines for Terraform plans/applies and Ansible blue/green deployments
- provide Ansible configuration, roles, and scripts plus detailed README for setup and operations

## Testing
- `terraform -chdir=infrastructure fmt -recursive` *(fails: terraform not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c920c2a8f48329bd13f7989dcc4ab2